### PR TITLE
Update README.md to reflect support for Laravel 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel HTMLMin is currently maintained by [Raza Mehdi](https://github.com/srmkl
 
 ## Installation
 
-Laravel HTMLMin requires [PHP](https://php.net) 5.5+, and supports Laravel 5.1, 5.2, 5.3, 5.4, and 5.4 only.
+Laravel HTMLMin requires [PHP](https://php.net) 5.5+, and supports Laravel 5.1, 5.2, 5.3, 5.4, and 5.5 only.
 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org):
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel HTMLMin is currently maintained by [Raza Mehdi](https://github.com/srmkl
 
 ## Installation
 
-Laravel HTMLMin requires [PHP](https://php.net) 5.5+. This particular version supports Laravel 5.1, 5.2, 5.3, or 5.4 only.
+Laravel HTMLMin requires [PHP](https://php.net) 5.5+, and supports Laravel 5.1+.
 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org):
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel HTMLMin is currently maintained by [Raza Mehdi](https://github.com/srmkl
 
 ## Installation
 
-Laravel HTMLMin requires [PHP](https://php.net) 5.5+, and supports Laravel 5.1, 5.2, 5.3, 5.4, and 5.5 only.
+Laravel HTMLMin requires [PHP](https://php.net) 5.5+. This particular version supports Laravel 5.1, 5.2, 5.3, 5.4, and 5.5 only.
 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org):
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel HTMLMin is currently maintained by [Raza Mehdi](https://github.com/srmkl
 
 ## Installation
 
-Laravel HTMLMin requires [PHP](https://php.net) 5.5+, and supports Laravel 5.1+.
+Laravel HTMLMin requires [PHP](https://php.net) 5.5+, and supports Laravel 5.1, 5.2, 5.3, 5.4, and 5.4 only.
 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org):
 


### PR DESCRIPTION
Alternatively, you could have it read as this:

`This particular version supports Laravel 5.1, 5.2, 5.3, 5.4, or 5.5 only.`

In any case, I believe that it's important to note that the package supports Laravel 5.5.