### PR TITLE
Allow minify compiler to render component alias

### DIFF
--- a/src/Compilers/MinifyCompiler.php
+++ b/src/Compilers/MinifyCompiler.php
@@ -44,15 +44,22 @@ class MinifyCompiler extends BladeCompiler
      * @param \Illuminate\Filesystem\Filesystem        $files
      * @param string                                   $cachePath
      * @param array                                    $ignoredPaths
+     * @param array                                    $customDirectives
      *
      * @return void
      */
-    public function __construct(BladeMinifier $blade, Filesystem $files, $cachePath, $ignoredPaths = [])
+    public function __construct(BladeMinifier $blade, Filesystem $files, $cachePath, $ignoredPaths = [], $customDirectives = [])
     {
         parent::__construct($files, $cachePath);
         $this->blade = $blade;
         $this->ignoredPaths = $ignoredPaths;
         $this->compilers[] = 'Minify';
+
+        if (count($customDirectives)) {
+            foreach ($customDirectives as $key => $value) {
+                $this->directive($key, $value);
+            }
+        }
     }
 
     /**

--- a/src/HTMLMinServiceProvider.php
+++ b/src/HTMLMinServiceProvider.php
@@ -164,12 +164,13 @@ class HTMLMinServiceProvider extends ServiceProvider
     protected function registerMinifyCompiler()
     {
         $this->app->singleton('htmlmin.compiler', function (Container $app) {
+            $oldCompiler = $app['blade.compiler'];
             $blade = $app['htmlmin.blade'];
             $files = $app['files'];
             $storagePath = $app->config->get('view.compiled');
             $ignoredPaths = $app->config->get('htmlmin.ignore', []);
 
-            return new MinifyCompiler($blade, $files, $storagePath, $ignoredPaths);
+            return new MinifyCompiler($blade, $files, $storagePath, $ignoredPaths, $oldCompiler->getCustomDirectives());
         });
 
         $this->app->alias('htmlmin.compiler', MinifyCompiler::class);


### PR DESCRIPTION
This pull request fix an issue when the original blade compiler have componet alias like `Blade::component('components.title', 'title');`.